### PR TITLE
Updated README.md to include install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ please consider contributing with [Patreon](https://www.patreon.com/dessant),
 Buster Client is a native app used by the [Buster](https://github.com/dessant/buster)
 extension for user input simulation.
 
+## Installation
+
+The [Buster browser extension](https://github.com/dessant/buster) requires the Buster Client app to be installed in order to function. You can download [the latest binaries here](https://github.com/dessant/buster-client/releases).
+
+### Installation on Windows
+
+Run the `.exe` installer and follow the onscreen instructions from the browser window that appears.
+
+### Installation on MacOS and Linux
+
+To install the client in MacOS and Linux, you will need to mark the downloaded binary as executable, then run the binary in your preferred terminal client. 
+
+```sh
+# 1. make file executable
+chmod +x buster-client-setup-*
+# 2. run installer
+./buster-client-setup-*
+```
+
+A new browser window will guide you through the rest of the install process.
+
 ## Issues
 
 Open issues on the [main repository](https://github.com/dessant/buster)


### PR DESCRIPTION
The unmarked MacOS and Linux binaries seemed slightly confusing, so I've added a short blurb explaining how to run them.

Instructions are copied from https://github.com/dessant/buster/issues/66

Thanks!